### PR TITLE
fix race condition in err goroutines; fix send on wrong goroutine

### DIFF
--- a/path.go
+++ b/path.go
@@ -218,10 +218,12 @@ func (pdp *pathDescriptionParser) parseCommandDrawingInstructions(l *gl.Lexer, i
 		return pdp.parseLineToRelDI()
 	case "L":
 		return pdp.parseLineToAbsDI()
-	case "H": fallthrough
+	case "H":
+		fallthrough
 	case "h":
 		return pdp.parseHLineToDI(i.Value == "H")
-	case "V": fallthrough
+	case "V":
+		fallthrough
 	case "v":
 		return pdp.parseVLineToDI(i.Value == "V")
 	case "z", "Z":

--- a/path_test.go
+++ b/path_test.go
@@ -18,3 +18,86 @@ func TestParsePath(t *testing.T) {
 		log.Printf("di: %+v, di.M: %+v", di, di.M)
 	}
 }
+
+type PathTest struct {
+	Description string
+	Svg     string
+	Kinds   []InstructionType
+	XCoords []float64
+	YCoords []float64
+}
+
+var tests = []PathTest{
+	{
+		"relative h-line test",
+		`<svg viewBox="0 0 100 100"><path d="M0.000 0.000 h100.000 50.000" fill="#000000" stroke="#000000" stroke-width="2"/></svg>`,
+		[]InstructionType{MoveInstruction, LineInstruction, LineInstruction, PaintInstruction},
+		[]float64{0, 100, 150, 0},
+		[]float64{0, 0, 0, 0},
+	},
+	{
+		"absolute h-line test",
+		`<svg viewBox="0 0 100 100"><path d="M0.000 0.000 H100.000 50.000" fill="#000000" stroke="#000000" stroke-width="2"/></svg>`,
+		[]InstructionType{MoveInstruction, LineInstruction, LineInstruction, PaintInstruction},
+		[]float64{0, 100, 50, 0},
+		[]float64{0, 0, 0, 0},
+	},
+	{
+		"relative v-line test",
+		`<svg viewBox="0 0 100 100"><path d="M0.000 0.000 v100.000 50.000" fill="#000000" stroke="#000000" stroke-width="2"/></svg>`,
+		[]InstructionType{MoveInstruction, LineInstruction, LineInstruction, PaintInstruction},
+		[]float64{0, 0, 0, 0},
+		[]float64{0, 100, 150, 0},
+	},
+	{
+		"absolute v-line test",
+		`<svg viewBox="0 0 100 100"><path d="M0.000 0.000 V100.000 50.000" fill="#000000" stroke="#000000" stroke-width="2"/></svg>`,
+		[]InstructionType{MoveInstruction, LineInstruction, LineInstruction, PaintInstruction},
+		[]float64{0, 0, 0, 0},
+		[]float64{0, 100, 50, 0},
+	},
+}
+
+func TestParsePathList(t *testing.T) {
+	for _, test := range tests {
+		svg, err := ParseSvg(test.Svg, "test", 0)
+		require.NoError(t, err)
+
+		dis, _ := svg.ParseDrawingInstructions()
+		strux := []*DrawingInstruction{}
+		for di := range dis {
+			strux = append(strux, di)
+			log.Printf("di: %+v, di.M: %+v", di, di.M)
+		}
+
+		if len(strux) != len(test.Kinds) {
+			t.Fatalf("expected %d instructions for test %s, but received %d", len(test.Kinds), test.Description, len(strux))
+		}
+
+		for i, kind := range test.Kinds {
+			if strux[i].Kind != kind {
+				t.Fatalf("expected instruction %d for test %s to be %d, but was %d", i, test.Description, kind, strux[i].Kind)
+			}
+		}
+
+		for i, x := range test.XCoords {
+			if strux[i].M == nil {
+				continue
+			}
+
+			if strux[i].M[0] != x {
+				t.Fatalf("expected X coordinate %d for test %s to be %f, but was %f", i, test.Description, x, strux[i].M[0])
+			}
+		}
+
+		for i, y := range test.YCoords {
+			if strux[i].M == nil {
+				continue
+			}
+
+			if strux[i].M[1] != y {
+				t.Fatalf("expected Y coordinate %d for test %s to be %f, but was %f", i, test.Description, y, strux[i].M[1])
+			}
+		}
+	}
+}

--- a/path_test.go
+++ b/path_test.go
@@ -7,18 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParsePath(t *testing.T) {
-	const svgAbsoluteLine = `<svg viewBox="0 0 100 100"><path d="M0.000 0.000 L100.000 0.000 L100.000 100.000 L0.000 100.000 Z" fill="#000000" stroke="#000000" stroke-width="2"/></svg>`
-
-	svg, err := ParseSvg(svgAbsoluteLine, "test", 0)
-	require.NoError(t, err)
-
-	dis, _ := svg.ParseDrawingInstructions()
-	for di := range dis {
-		log.Printf("di: %+v, di.M: %+v", di, di.M)
-	}
-}
-
 type PathTest struct {
 	Description string
 	Svg     string
@@ -28,6 +16,20 @@ type PathTest struct {
 }
 
 var tests = []PathTest{
+	{
+		"absolute lines",
+		`<svg viewBox="0 0 100 100"><path d="M0.000 0.000 L100.000 0.000 100.000 100.000 L0.000 100.000 Z" fill="#000000" stroke="#000000" stroke-width="2"/></svg>`,
+		[]InstructionType{MoveInstruction, LineInstruction, LineInstruction, LineInstruction, CloseInstruction, PaintInstruction},
+		[]float64{0, 100, 100, 0,   0},
+		[]float64{0, 0,   100, 100, 0},
+	},
+	{
+		"relative lines",
+		`<svg viewBox="0 0 100 100"><path d="M0.000 0.000 l100.000 0.000 100.000 100.000 l0.000 100.000 Z" fill="#000000" stroke="#000000" stroke-width="2"/></svg>`,
+		[]InstructionType{MoveInstruction, LineInstruction, LineInstruction, LineInstruction, CloseInstruction, PaintInstruction},
+		[]float64{0, 100, 200, 200, 0},
+		[]float64{0, 0,   100, 200, 0},
+	},
 	{
 		"relative h-line test",
 		`<svg viewBox="0 0 100 100"><path d="M0.000 0.000 h100.000 50.000" fill="#000000" stroke="#000000" stroke-width="2"/></svg>`,

--- a/path_test.go
+++ b/path_test.go
@@ -9,10 +9,10 @@ import (
 
 type PathTest struct {
 	Description string
-	Svg     string
-	Kinds   []InstructionType
-	XCoords []float64
-	YCoords []float64
+	Svg         string
+	Kinds       []InstructionType
+	XCoords     []float64
+	YCoords     []float64
 }
 
 var tests = []PathTest{
@@ -20,15 +20,15 @@ var tests = []PathTest{
 		"absolute lines",
 		`<svg viewBox="0 0 100 100"><path d="M0.000 0.000 L100.000 0.000 100.000 100.000 L0.000 100.000 Z" fill="#000000" stroke="#000000" stroke-width="2"/></svg>`,
 		[]InstructionType{MoveInstruction, LineInstruction, LineInstruction, LineInstruction, CloseInstruction, PaintInstruction},
-		[]float64{0, 100, 100, 0,   0},
-		[]float64{0, 0,   100, 100, 0},
+		[]float64{0, 100, 100, 0, 0},
+		[]float64{0, 0, 100, 100, 0},
 	},
 	{
 		"relative lines",
 		`<svg viewBox="0 0 100 100"><path d="M0.000 0.000 l100.000 0.000 100.000 100.000 l0.000 100.000 Z" fill="#000000" stroke="#000000" stroke-width="2"/></svg>`,
 		[]InstructionType{MoveInstruction, LineInstruction, LineInstruction, LineInstruction, CloseInstruction, PaintInstruction},
 		[]float64{0, 100, 200, 200, 0},
-		[]float64{0, 0,   100, 200, 0},
+		[]float64{0, 0, 100, 200, 0},
 	},
 	{
 		"relative h-line test",
@@ -65,7 +65,11 @@ func TestParsePathList(t *testing.T) {
 		svg, err := ParseSvg(test.Svg, "test", 0)
 		require.NoError(t, err)
 
-		dis, _ := svg.ParseDrawingInstructions()
+		dis, errChan := svg.ParseDrawingInstructions()
+		for err := range errChan {
+			require.NoError(t, err)
+		}
+
 		strux := []*DrawingInstruction{}
 		for di := range dis {
 			strux = append(strux, di)

--- a/path_test.go
+++ b/path_test.go
@@ -79,29 +79,25 @@ func TestParsePathList(t *testing.T) {
 			t.Fatalf("expected %d instructions for test %s, but received %d", len(test.Kinds), test.Description, len(strux))
 		}
 
-		for i, kind := range test.Kinds {
-			if strux[i].Kind != kind {
-				t.Fatalf("expected instruction %d for test %s to be %d, but was %d", i, test.Description, kind, strux[i].Kind)
+		for i, stru := range strux {
+			if stru.Kind != test.Kinds[i] {
+				t.Fatalf("expected instruction %d for test %s to be %d, but was %d", i, test.Description, test.Kinds[i], stru.Kind)
 			}
-		}
 
-		for i, x := range test.XCoords {
-			if strux[i].M == nil {
+			if stru.M == nil {
 				continue
 			}
 
-			if strux[i].M[0] != x {
-				t.Fatalf("expected X coordinate %d for test %s to be %f, but was %f", i, test.Description, x, strux[i].M[0])
+			if stru.M[0] != test.XCoords[i] {
+				t.Fatalf("expected X coordinate %d for test %s to be %f, but was %f", i, test.Description, test.XCoords[i], stru.M[0])
 			}
-		}
 
-		for i, y := range test.YCoords {
-			if strux[i].M == nil {
+			if stru.M == nil {
 				continue
 			}
 
-			if strux[i].M[1] != y {
-				t.Fatalf("expected Y coordinate %d for test %s to be %f, but was %f", i, test.Description, y, strux[i].M[1])
+			if stru.M[1] != test.YCoords[i] {
+				t.Fatalf("expected Y coordinate %d for test %s to be %f, but was %f", i, test.Description, test.YCoords[i], stru.M[1])
 			}
 		}
 	}

--- a/path_test.go
+++ b/path_test.go
@@ -1,7 +1,6 @@
 package svg
 
 import (
-	"log"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -73,7 +72,7 @@ func TestParsePathList(t *testing.T) {
 		strux := []*DrawingInstruction{}
 		for di := range dis {
 			strux = append(strux, di)
-			log.Printf("di: %+v, di.M: %+v", di, di.M)
+			t.Logf("di: %+v, di.M: %+v", di, di.M)
 		}
 
 		if len(strux) != len(test.Kinds) {

--- a/svg.go
+++ b/svg.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"sync"
 
 	mt "github.com/smallpdf/Mtransform"
 )
@@ -60,15 +61,19 @@ func (g *Group) ParseDrawingInstructions() (chan *DrawingInstruction, chan error
 	g.instructions = make(chan *DrawingInstruction, 100)
 	g.errors = make(chan error, 100)
 
+	errWg := &sync.WaitGroup{}
+
 	go func() {
 		defer close(g.instructions)
-		defer close(g.errors)
+		defer func() { errWg.Wait(); close(g.errors) }()
 		for _, e := range g.Elements {
 			instrs, errs := e.ParseDrawingInstructions()
+			errWg.Add(1)
 			go func() {
 				for er := range errs {
 					g.errors <- er
 				}
+				errWg.Done()
 			}()
 			for is := range instrs {
 				g.instructions <- is
@@ -148,16 +153,19 @@ func (s *Svg) ParseDrawingInstructions() (chan *DrawingInstruction, chan error) 
 	s.errors = make(chan error, 100)
 
 	go func() {
+		errWg := &sync.WaitGroup{}
 		var elecount int
 		defer close(s.instructions)
-		defer close(s.errors)
+		defer func() { errWg.Wait(); close(s.errors) }()
 		for _, e := range s.Elements {
 			elecount++
 			instrs, errs := e.ParseDrawingInstructions()
+			errWg.Add(1)
 			go func(count int) {
 				for er := range errs {
 					s.errors <- fmt.Errorf("error when parsing element nr. %d: %s", count, er)
 				}
+				errWg.Done()
 			}(elecount)
 
 			for is := range instrs {
@@ -167,10 +175,12 @@ func (s *Svg) ParseDrawingInstructions() (chan *DrawingInstruction, chan error) 
 
 		for _, g := range s.Groups {
 			instrs, errs := g.ParseDrawingInstructions()
+			errWg.Add(1)
 			go func() {
 				for er := range errs {
-					g.errors <- er
+					s.errors <- er
 				}
+				errWg.Done()
 			}()
 			for is := range instrs {
 				s.instructions <- is


### PR DESCRIPTION
Howdy!

One bug is pretty serious, which is that on line 172 of svg.go you attempt a send on the wrong error channel; the send should occur on `s.errors` instead of `g.errors`.

Someone less important but still worth fixing, in my opinion, is that the treatment of goroutines and channels with regard to errors has a race condition. Because the order of execution of goroutines is undefined without synchronizing events, it's possible for the `defer close(g.errors)` / `defer close(s.errors)` to actually execute before (or concurrently) with the sub-goroutine send on that channel; this results in a panic, because a send on a closed channel is a fatal error.

I fix this in the PR below with `sync.WaitGroup`, by ensuring that any sending goroutines have exited before closing the corresponding channel.

Thanks,
- Patrick

p.s., I also implemented handling of `h`/`H` and `v`/`V` as well as tests for these and more comprehensive and DRY tests for path parsing.